### PR TITLE
gevent 1.3.6 requires greenlet 0.4.14 or above

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
   run:
     - cffi >=1.11.5
     - python
-    - greenlet >=0.4.13
+    - greenlet >=0.4.14
 
 test:
   imports:


### PR DESCRIPTION
http://www.gevent.org/changelog.html#id2