### PR TITLE
gevent 26.4.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gevent" %}
-{% set version = "25.8.2" %}
+{% set version = "26.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0cfab118ad5dcc55d7847dd9dccd560d9015fe671f42714b6f1ac97e3b2b9a3a
+  sha256: 288d03addfccf0d1c67268358b6759b04392bf3bc35d26f3d9a45c82899c292d
 
 build:
   number: 0


### PR DESCRIPTION
gevent 26.4.0 

**Destination channel:** Defaults

### Links

- [PKG-13511]
- dev_url:        https://github.com/gevent/gevent/tree/26.4.0
- conda_forge:    https://github.com/conda-forge/gevent-feedstock
- pypi:           https://pypi.org/project/gevent/26.4.0
- pypi inspector: https://inspector.pypi.io/project/gevent/26.4.0

### Explanation of changes:

- new version number


[PKG-13511]: https://anaconda.atlassian.net/browse/PKG-13511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ